### PR TITLE
Use fixed RNG seed for deterministic label generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ g++(c++17) 14.2.0, x64
 
 g++ -Wall -Wextra -g3 -O3 -std=c++17 main.cpp query_decomposition.cpp TDTree.cpp Utils.cpp -o td_tree.o
 
+# Temporal Graph File Format
+
+The helper that loads temporal graphs expects each line of the data file to
+contain three integers: `src dst time`. During loading, labels for vertices and
+edges are synthesised from the set `{A, B, C, D, E}` using a fixed random seed
+to make results reproducible across runs.
+
 # Method
 
 td_tree.o {data_graph} {query_graph} {threshold(integer)}

--- a/ours/Utils.cpp
+++ b/ours/Utils.cpp
@@ -76,11 +76,12 @@ bool readTemporalGraph(const std::string& filename, Graph& graph) {
 
     std::string line;
 
-    // Random generator for labels
+    // Random generator for labels using a fixed seed so that tests are
+    // reproducible across runs. If deterministic behaviour is not desired, the
+    // seed value below can be replaced with a runtime configurable one.
     std::vector<std::string> labels = {"A", "B", "C", "D", "E"};
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    std::uniform_int_distribution<> dis(0, labels.size() - 1);
+    std::mt19937 gen(42);  // Fixed seed for deterministic label assignment
+    std::uniform_int_distribution<> dis(0, static_cast<int>(labels.size()) - 1);
 
     int max_vertex = -1;
 


### PR DESCRIPTION
## Summary
- Ensure `readTemporalGraph` uses a fixed random seed so generated labels are reproducible across runs
- Document temporal graph file format and deterministic label assignment

## Testing
- `g++ -Wall -Wextra -g3 -O3 -std=c++17 ours/main.cpp ours/query_decomposition.cpp ours/TDTree.cpp ours/Utils.cpp -o ours/td_tree.o`


------
https://chatgpt.com/codex/tasks/task_e_68b551e4d4d4832db8c910b013931489